### PR TITLE
Fix mobile styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <div class="landing">
 
-<img src=images/logo.png height=500px />
+<img id="logo" src=images/logo.png />
 
 <br />
 <h3>You like ethereum? You wish you could use it, BUT TRANSACTIONS ARE <span class="emphasize">100</span> FUCKING DOLLARS?!?</h3>

--- a/style.css
+++ b/style.css
@@ -48,10 +48,16 @@ img.sm {
 .arrow {
     border: solid white;
     border-width: 0 10px 10px 0;
-    display: inline-block;
+    display: none;
     padding: 10px;
     transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
+}
+
+#logo {
+    max-width: 500px;
+    width: 100%;
+    height: auto;
 }
 
 #setup {
@@ -59,6 +65,9 @@ img.sm {
 }
 
 @media only screen and (min-width: 800px) {
+    .arrow {
+         display: inline-block;
+    }
     .landing {
         height: 100vmin;
     }


### PR DESCRIPTION
I didn't realize in my last PR that the website was still broken on mobile. 
There was a `height=500px` in the html on the logo, making the page always be at least 500px wide, now fixed so that it will scale.
Also I made the arrow telling you to scroll down get removed on mobile since you can see the text below anyways.

My cTH wallet is `0x0bA1769110e9F055EdcC9a2DFA707b3B7322F900` ;)