### PR TITLE
fix: twitter page errors

### DIFF
--- a/twitter.html
+++ b/twitter.html
@@ -1,28 +1,28 @@
 <html>
-<head>
-<style>
-pre {
-  display: block;
-  font-family: monospace;
-  white-space: pre;
-  margin: 1em 0;
-  width: 600px;
-  white-space: pre-wrap;
-}
-</style>
-</head>
-<body>
-<pre>
-<h1>Tweet for free cTH</h1>
-<hr/>
+	<head>
+		<style>
+			pre {
+				display: block;
+				font-family: monospace;
+				white-space: pre;
+				margin: 1em 0;
+				width: 600px;
+				white-space: pre-wrap;
+			}
+		</style>
+	</head>
+	<body>
+		<pre>
+  <h1>Tweet for free cTH</h1>
+  <hr/>
 Share CheapEth on Twitter and get free cTH
 
 * Tweet and include one of these: ["cheapeth", "cheapethereum", "#cth", "$CTH"]
 * Then post in discord bot channel: $cheap twitter &#60;twitterID&#62; &#60;your cth arrd&#62;
 
-Get your twitter ID from this site: https://tweeterid.com/
+Get your twitter ID from this site: <a href="https://tweeterid.com/">https://tweeterid.com/</a>
 
-<1000 folllowers = 1cTH
+&lt;1000 followers = 1cth
 1000-2000 followers = 2cTH
 2000+ followers = 3cTH
 
@@ -30,6 +30,7 @@ Transaction doesn't show on block explorer, so check balance before and after
 
 Contract address: 0xe165fDE95bd15ded816d1DD4345BE4B24b0133d9
 
-NO SPAM ACCOUNTS (min age 30 days, min followers 5)
-
-
+NO SPAM ACCOUNTS (min account age 30 days, min followers 10)
+  </pre>
+	</body>
+</html>


### PR DESCRIPTION
the discord thing says

```
$cheap twitter 

Tweet about CheapEth and get rewarded ("$cheap help twitter")
* Tweet and include any of these keywords ["cheapeth", "cheapethereum", "#cth", "$CTH"]
* Type "$cheap twitter <twitterID> <your cth arrd>"
* Get your twitter ID from: https://tweeterid.com/
* <1000 followers = 1cth
* 1000-2000 followers = 2cth
* 2000+ followers = 3cth
* Check balance before and after as transaction not on explorer
* 1 reward per user
* Min account age 30 days, min followers 10
```

And the websites shows a different version of it so I changed it.